### PR TITLE
Prevent a call to std::log10(0) when workers == 1

### DIFF
--- a/src/mpistat.cc
+++ b/src/mpistat.cc
@@ -268,7 +268,7 @@ int main(int argc, char **argv) {
   }
 
   // sort out the per-type output file format
-  uint64_t digits = std::log10(workers-1)+1;
+  uint64_t digits = std::log10(workers+1)+1;
   sprintf(out_file_format, "%s/%%0%ldld_%%c.out.gz", argv[1],digits);
 
   // set the create work callback


### PR DESCRIPTION
Side effect of having std::log10(0) is that no output files are created due to bad out_file_format string.